### PR TITLE
rsound replacing beep for cross platform compatibility

### DIFF
--- a/examples/racket/bleep.bak
+++ b/examples/racket/bleep.bak
@@ -1,7 +1,6 @@
 #lang racket
 
 (require racket/gui)
-(require rsound)
 
 ; Scale used by slider
 (define *min-position* 0)
@@ -22,9 +21,9 @@
 
 ; Generate a tone using the beep utility
 (define (generate-tone button event)
-  (play (make-tone  (string->number (send frequency-field get-value))
-                    0.5
-                    (* 22 (string->number (send duration-field get-value))))))
+  (system (format "beep -f ~a -l ~a"
+                  (send frequency-field get-value)
+                  (send duration-field get-value))))
 
 ; Logarithmic scale for frequency (so middle A [440] falls about in the middle)
 ; Adapted from https://stackoverflow.com/questions/846221/logarithmic-slider


### PR DESCRIPTION
Hi! First pr ever, Im learning racket/lisp.

Seems to me that beep.exe isnt "the natural way of doing beep " in windows, if you are lucky enough  to find  at least one of the multiple open source beeps.exe  around that works with the windows version installed, then you'll need to make it visible in the path, and maybe the laptop dont have speakers.

So i just replaced it with rsound package. Making the app cross-platform

By the way, this beep.exe seems to work without modifications, at least in my pc.
https://www.rlvision.com/misc/beep.php