### PR TITLE
Implement tone in LamdaNative example with rtaudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,11 @@ cd lisp-gui-examples/examples
 ![Screenshot](screenshots/lambdanative.png?raw=true "LambdaNative screenshot")
 
 Navigate to the `lambdanative` example subdirectory and execute the `bleep`
-executable. You'll probably have to preface the command with `sudo` to actually
-control your PC speaker. See "A note about ioctl" in the
-[README](https://github.com/johnath/beep) for beep.
+executable.
 
 ```bash
 cd lambdanative
-sudo ./bleep
+./bleep
 ```
 
 To build the example from source, see the README in the `lambdanative` example

--- a/examples/lambdanative/README.md
+++ b/examples/lambdanative/README.md
@@ -1,6 +1,6 @@
 # Building
 
-* [Set up LambdaNative.](https://dev.to/goober99/learn-lambdanative-by-example-desktop-gui-277l#installing-lambdanative)
+* [Set up LambdaNative.](https://github.com/goober99/lisp-gui-examples/blob/master/examples/lambdanative/tutorial.md#installing-lambdanative)
 
 * Copy `apps/bleep` into your LambdaNative apps directory (`cp -r apps/bleep ~/lambdanative/apps`).
 

--- a/examples/lambdanative/apps/bleep/MODULES
+++ b/examples/lambdanative/apps/bleep/MODULES
@@ -1,1 +1,1 @@
-config eventloop ln_core ln_glcore ln_glgui
+config eventloop ln_core ln_glcore ln_glgui rtaudio

--- a/examples/lambdanative/apps/bleep/main.scm
+++ b/examples/lambdanative/apps/bleep/main.scm
@@ -1,4 +1,4 @@
-;; bleep - GUI frontend for beep made with LambdaNative
+;; bleep - GUI for generating a tone made with LambdaNative
 
 (define gui #f)
 
@@ -11,8 +11,8 @@
 (define *min-position* 0)
 (define *max-position* 2000)
 ;; Range of frequencies
-(define *min-frequency* 1)
-(define *max-frequency* 19999)
+(define *min-frequency* 20)
+(define *max-frequency* 20000)
 ;; Notes -> frequency (middle A-G [A4-G4])
 ;; http://pages.mtu.edu/~suits/notefreqs.html
 (define notes (list->table '((0 . 440.00)    ; A
@@ -28,8 +28,9 @@
 
 #include <math.h>
 
-void rtaudio_register(void (*)(int), void (*)(float), void (*)(float*,float*));
+void rtaudio_register(void (*)(int), void (*)(float), void (*)(float*,float*), void (*)(void));
 
+double f;
 double srate=0;
 float buffer;
 
@@ -37,26 +38,26 @@ void my_realtime_init(int samplerate) { srate=(double)samplerate; buffer=0; }
 void my_realtime_input(float v) { }
 void my_realtime_output(float *v1,float *v2) {
   static double t=0;
-  buffer = 0.95*sin(2*M_PI*440.*t);
+  buffer = 0.95*sin(2*M_PI*f*t);
   *v1=*v2=(float)buffer;
   t+=1/srate;
 }
+void my_realtime_close() { buffer=0; }
 
 end-of-c-declare
 )
-(c-initialize "rtaudio_register(my_realtime_init,my_realtime_input,my_realtime_output);")
+(c-initialize "rtaudio_register(my_realtime_init,my_realtime_input,my_realtime_output,my_realtime_close);")
+(define rtaudio-frequency (c-lambda (double) void "f=___arg1;"))
 
-;; Generate a tone using the beep utility
-(define tone-end #f)
+;; Generate a tone using the rtaudio module
 (define (generate-tone parent widget event x y)
   ; Make sure neither frequency or duration were left blank
   (if (= (string-length (glgui-widget-get parent frequency-field 'label)) 0) (set-frequency 1))
   (if (= (string-length (glgui-widget-get parent duration-field 'label)) 0) (glgui-widget-set! parent duration-field 'label "1 ms"))
-  (rtaudio-start 8000 0.5)
-  (set! tone-end (+ (current-milliseconds) (string->number (chop-units (glgui-widget-get parent duration-field 'label))))))
-
-;;  (shell-command (string-append "beep -f " (chop-units (glgui-widget-get parent frequency-field 'label))
-;;                                " -l " (chop-units (glgui-widget-get parent duration-field 'label)))))
+  (rtaudio-frequency (exact->inexact (string->number (chop-units (glgui-widget-get parent frequency-field 'label)))))
+  (rtaudio-start 44100 0.5)
+  (thread-sleep! (/ (string->number (chop-units (glgui-widget-get parent duration-field 'label))) 1000))
+  (rtaudio-stop))
 
 ;; Logarithmic scale for frequency (so middle A [440] falls about in the middle)
 ;; Adapted from https://stackoverflow.com/questions/846221/logarithmic-slider
@@ -173,9 +174,6 @@ end-of-c-declare
       (if (= x EVENT_KEYESCAPE) (terminate))))
     ;; Also update frequency when dragging slider (callback is only on release)
     (if (and (glgui-widget-get gui slider 'downval) (= t EVENT_MOTION)) (adjust-frequency))
-    (cond [(and tone-end (>= (current-milliseconds) tone-end))
-      (rtaudio-stop)
-      (set! tone-end #f)])
     (glgui-event gui t x y))
 ;; termination
   (lambda () #t)

--- a/examples/lambdanative/apps/bleep/main.scm
+++ b/examples/lambdanative/apps/bleep/main.scm
@@ -47,14 +47,12 @@ end-of-c-declare
 (c-initialize "rtaudio_register(my_realtime_init,my_realtime_input,my_realtime_output);")
 
 ;; Generate a tone using the beep utility
-(define tone-sounding #f)
-(define tone-end 0)
+(define tone-end #f)
 (define (generate-tone parent widget event x y)
   ; Make sure neither frequency or duration were left blank
   (if (= (string-length (glgui-widget-get parent frequency-field 'label)) 0) (set-frequency 1))
   (if (= (string-length (glgui-widget-get parent duration-field 'label)) 0) (glgui-widget-set! parent duration-field 'label "1 ms"))
   (rtaudio-start 8000 0.5)
-  (set! tone-sounding #t)
   (set! tone-end (+ (current-milliseconds) (string->number (chop-units (glgui-widget-get parent duration-field 'label))))))
 
 ;;  (shell-command (string-append "beep -f " (chop-units (glgui-widget-get parent frequency-field 'label))
@@ -175,9 +173,9 @@ end-of-c-declare
       (if (= x EVENT_KEYESCAPE) (terminate))))
     ;; Also update frequency when dragging slider (callback is only on release)
     (if (and (glgui-widget-get gui slider 'downval) (= t EVENT_MOTION)) (adjust-frequency))
-    (cond [(and tone-sounding (>= (current-milliseconds) tone-end))
+    (cond [(and tone-end (>= (current-milliseconds) tone-end))
       (rtaudio-stop)
-      (set! tone-sounding #f)])
+      (set! tone-end #f)])
     (glgui-event gui t x y))
 ;; termination
   (lambda () #t)


### PR DESCRIPTION
Make the LambdaNative example cross-platform by implementing the tone with the built-in LN module rtaudio instead of using an external Linux CLI app